### PR TITLE
feat: implement block, template, and layout for coupon popup(#5)

### DIFF
--- a/Block/Coupon.php
+++ b/Block/Coupon.php
@@ -1,0 +1,88 @@
+<?php
+namespace Mauro\CustomerCouponShow\Block;
+
+use Magento\Framework\View\Element\Template;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Framework\Registry;
+
+class Coupon extends Template
+{
+    const XML_PATH_ENABLED = 'discount_coupons_section/general/enabled';
+    const XML_PATH_CATEGORY_ID = 'discount_coupons_section/general/category_id';
+    const XML_PATH_DELAY_OPEN = 'discount_coupons_section/general/delay_open';    
+    const XML_PATH_DISCOUNT = 'discount_coupons_section/general/discount';
+    const XML_PATH_EXPIRATION = 'discount_coupons_section/general/expiration';
+
+    protected $scopeConfig;
+    protected $registry;
+
+    public function __construct(
+        Template\Context $context,
+        ScopeConfigInterface $scopeConfig,
+        Registry $registry,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->scopeConfig = $scopeConfig;
+        $this->registry = $registry;
+    }
+
+    public function getEnabled()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_ENABLED,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    public function getCategoryId()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_CATEGORY_ID,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    public function getDelayOpen()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_DELAY_OPEN,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    public function getDiscount()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_DISCOUNT,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+
+    public function getExpiration()
+    {
+        return $this->scopeConfig->getValue(
+            self::XML_PATH_EXPIRATION,
+            ScopeInterface::SCOPE_STORE
+        );
+    }
+    
+    public function getCurrentCategory()
+    {
+        $category = $this->registry->registry('current_category');
+        return $category ? $category->getId() : null;
+    }
+
+    public function shouldRender(): bool
+    {
+        if (!$this->getEnabled()) return false;
+        
+        $configCategoryId = $this->getCategoryId();
+        $currentCategoryId = $this->getCurrentCategory();
+
+        
+        if ($configCategoryId != $currentCategoryId) return false;
+        return true;
+    }
+}

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <head>
+        <css src="Mauro_CustomerCouponShow::css/coupon.css"/>
+    </head>
+    <body>
+        <referenceContainer name="before.body.end">
+                <block
+                    class="Mauro\CustomerCouponShow\Block\Coupon"
+                    name="customer_coupon_show_block"
+                    template="Mauro_CustomerCouponShow::coupon.phtml"/>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/frontend/templates/coupon.phtml
+++ b/view/frontend/templates/coupon.phtml
@@ -1,0 +1,66 @@
+<?php 
+    $delay = $block->getDelayOpen(); 
+    $discount = $block->getDiscount();
+    $expiration = $block->getExpiration();
+?>
+
+<?php if (!$block->shouldRender()) return; ?>
+
+<div id="offer-popup" >
+    <div class="popup-content">
+        <button id="close-popup">&times;</button>
+        
+        <div class="popup-icon">
+            <svg width="80" height="80" viewBox="0 0 24 24" fill="none">
+                <path d="M12 2L15.09 8.26L22 9.27L17 14.14L18.18 21.02L12 17.77L5.82 21.02L7 14.14L2 9.27L8.91 8.26L12 2Z" fill="url(#gradient)" stroke="#FFD700" stroke-width="1"/>
+                <defs>
+                    <linearGradient id="gradient" x1="12" y1="2" x2="12" y2="21">
+                        <stop offset="0%" stop-color="#FFD700"/>
+                        <stop offset="100%" stop-color="#FFA500"/>
+                    </linearGradient>
+                </defs>
+            </svg>
+        </div>
+
+        <h2 class="popup-title">SPECIAL OFFER!</h2>
+        <div class="popup-discount">
+            <span class="discount-number"><?php echo $discount; ?>%</span>
+            <span class="discount-text">OFF</span>
+        </div>
+        <p class="popup-subtitle">Don’t miss this amazing opportunity</p>
+        
+        <div class="popup-features">
+            <div class="feature">
+                <span class="check">✓</span> Free shipping
+            </div>
+            <div class="feature">
+                <span class="check">✓</span> Valid for a limited time
+            </div>
+            <div class="feature">
+                <span class="check">✓</span> All products
+            </div>
+        </div>
+
+        <button id="accept-popup" class="cta-button">
+            GET MY DISCOUNT!
+            <span class="arrow">→</span>
+        </button>
+        
+        <p class="popup-timer">
+            ⏰ Offer expires in: 
+            <span id="countdown" data-expiration="
+            <?= (int)$expiration?>">00:00</span>
+            
+        </p>
+    </div>
+</div>
+
+<script type="text/x-magento-init">
+{
+    "*": {
+        "Mauro_CustomerCouponShow/js/coupon": {
+            "delay": <?= (int)$delay * 1000 ?>
+        }
+    }
+}
+</script>


### PR DESCRIPTION
This PR implements the backend block, frontend template, and layout for the `Mauro_CustomerCouponShow` popup.  
It ensures the block fetches configuration values and renders the popup correctly on frontend pages.